### PR TITLE
Switch GPIO to libgpiod v2 (python3-libgpiod) for Pi 5 compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,9 +189,12 @@ These are the generic base classes. In practice, each real hardware driver defin
 
 ### `sensor/power_meter.py` — Power Meter (PZEM-017, RS485 Modbus)
 
-- Currently a standalone scanner/diagnostic script, not a proper sensor module.
-- Communicates via RS485 using Modbus RTU with GPIO DE/RE pin control (GPIO 17 via sysfs).
-- CRC-16 calculation included. Serial port `/dev/ttyAMA10` at 9600 baud.
+- Interface: `setup(port, baudrate, de_re_pin, modbus_address, gpio_chip)`, `read()`, `close()`
+- Exceptions: `PowerSensorSetupError`, `PowerSensorReadError`
+- Communicates via RS485 Modbus RTU. DE/RE direction pin controlled via **`gpiod` (libgpiod v2)** — no sysfs, no `RPi.GPIO`.
+- GPIO chip: `/dev/gpiochip4` (Pi 5 default) or `/dev/gpiochip0` (Pi 4) — passed from `config.xml`.
+- Abstracted GPIO helpers: `_gpio_open()` (chip + line request), `_gpio_tx()` / `_gpio_rx()` (direction toggle), `_gpio_close()` (teardown).
+- CRC-16 included. Serial port and Modbus address from `config.xml`.
 
 ### `sensor/rpi_master.py` — Raspberry Pi I2C Master (Test Script)
 
@@ -324,7 +327,8 @@ Parsed once at startup by the GUI tools. Contains:
 
 ## Platform Constraints
 
-- **`smbus`, `lgpio`, `RPi.GPIO`, `board`, `busio` are Linux/Pi-only** — hardware sensor modules will not import on Windows. Always use `dev_stack.py` on development machines.
+- **`smbus`, `gpiod`, `board`, `busio` are Linux/Pi-only** — hardware sensor modules will not import on Windows. Always use `dev_stack.py` on development machines.
+- **GPIO library is `gpiod` (libgpiod v2, installed as `python3-libgpiod` via apt).** Do not use `RPi.GPIO` or `lgpio` — neither works on the Pi 5 RP1 GPIO chip. The GPIO character device is `/dev/gpiochip4` on Pi 5 and `/dev/gpiochip0` on Pi 4. All `gpiod` imports must be guarded with `try/except ImportError`.
 - **`pynmea2` is not available via apt** — requires a separate Python venv with `--system-site-packages` on Pi. Guard GPS import with `try/except ImportError`.
 - **`air.py` calls `setup()` and `disable_abc()` at module level** — importing it on a non-Pi machine will attempt to open a serial port and fail immediately.
 - **On Raspberry Pi**, install Python packages via `apt`, not `pip` on system Python. See `herc_26_raspberry_pi_setup_guide_readme.md`.
@@ -336,7 +340,7 @@ Parsed once at startup by the GUI tools. Contains:
 
 These are existing inconsistencies noted for future cleanup:
 
-1. **`soil.py` and `power_meter.py` are standalone scripts**, not proper sensor modules with `setup()`/`read()`/`close()`. They need to be refactored before being integrated into the real deployment stack.
+1. **`soil.py` is a standalone script**, not a proper sensor module with `setup()`/`read()`/`close()`. It needs to be refactored before being integrated into the real deployment stack. (`power_meter.py` has been refactored — it now has a proper interface and uses libgpiod.)
 2. **`gps.py` uses `open()` instead of `setup()`**, deviating from the standard interface pattern.
 3. **`air.py` calls `setup()` at module import level** (outside `if __name__ == "__main__"`), causing immediate serial port access on import — this is a bug.
 4. **`sensor/rpi_master.py`** is an I2C test script, not a driver module.
@@ -464,7 +468,7 @@ Must be fixed before deploying to Raspberry Pi:
 
 - 🔴 **`sensor/soil.py` — module-level hardware access, no proper interface**. Full refactor: `SoilSensorSetupError`, `SoilSensorReadError`, `setup()`, `read()`, `close()`.
 
-- 🔴 **`sensor/power_meter.py` — GPIO at module level, no proper interface**. Full refactor: `PowerSensorSetupError`, `PowerSensorReadError`, `setup()`, `read()`, `close()`.
+- ✅ **`sensor/power_meter.py` — refactored**. Proper `setup()`/`read()`/`close()` interface, `PowerSensorSetupError`/`PowerSensorReadError`, libgpiod v2 GPIO (`python3-libgpiod`).
 
 - 🔴 **`dev_stack.py` — IMU dict missing `orientation` key**. `data.imu.orientation.{roll,pitch,yaw}` is in the snapshot schema but dev_stack doesn't output it. `imu_roll_deg/pitch_deg/yaw_deg` always write -1. Fix dev_stack in sync with fixing `imu.py`.
 
@@ -494,7 +498,7 @@ Must be fixed before deploying to Raspberry Pi:
 
 - 🟡 **`sensor/soil.py` — needs full refactor**. `read()` must return `{raw:{moisture}, sensor_voltage:{moisture}, moisture_value}`. Calibration from `config.xml`.
 
-- 🟡 **`sensor/power_meter.py` — needs full refactor**. `read()` must return `{voltage_v, current_a, power_w}`. Port/address from `config.xml`.
+- ✅ **`sensor/power_meter.py` — refactored**. Returns `{voltage_v, current_a, power_w}`. Port/address/GPIO chip from `config.xml`.
 
 - 🟡 **`sensor/gps.py` — snapshot keys don't match schema**. Returns `utc_time`, `utc_date`, `speed_knots`, `course_deg`; schema uses `timestamp`, `lat`, `lon`. Reconcile.
 

--- a/herc_26_raspberry_pi_setup_guide_readme.md
+++ b/herc_26_raspberry_pi_setup_guide_readme.md
@@ -8,7 +8,8 @@ It is written for **Raspberry Pi OS 64-bit (Bookworm / Trixie)** and assumes the
 
 ## Target Platform
 
-- Raspberry Pi 4 or Raspberry Pi 5
+- Raspberry Pi 5 (primary target — uses `/dev/gpiochip4`)
+- Raspberry Pi 4 (also supported — uses `/dev/gpiochip0`)
 - Raspberry Pi OS 64-bit
 - System Python 3
 - No virtual environments for the main system
@@ -69,24 +70,25 @@ sudo apt install -y \
   i2c-tools \
   python3-full \
   python3-dev \
-  python3-lgpio \
-  liblgpio1 \
+  python3-libgpiod \
   python3-smbus \
   python3-serial \
-  python3-rpi.gpio \
   python3-tk
 ```
 
 ### Why These Are Needed
 
-| Package            | Used By                         |
-|--------------------|---------------------------------|
-| python3-smbus      | TMP102, DFRobot ADS1115         |
-| python3-serial     | GPS, RS485 power meter          |
-| python3-rpi.gpio   | Legacy power meter code         |
-| python3-tk         | All GUIs                        |
-| python3-lgpio      | GPIO backend                    |
-| i2c-tools          | I2C debugging                   |
+| Package            | Used By                                          |
+|--------------------|--------------------------------------------------|
+| python3-libgpiod   | RS485 DE/RE GPIO control in power_meter.py       |
+| python3-smbus      | TMP102, DFRobot ADS1115                          |
+| python3-serial     | GPS, RS485 power meter                           |
+| python3-tk         | All GUIs                                         |
+| i2c-tools          | I2C debugging (`i2cdetect`)                      |
+
+> **Pi 5 vs Pi 4 GPIO chip:** `python3-libgpiod` uses the kernel character device
+> ABI (`/dev/gpiochipN`). On Pi 5 this is `/dev/gpiochip4`; on Pi 4 it is
+> `/dev/gpiochip0`. Set `gpio_chip` in `config.xml` to match your board.
 
 ---
 
@@ -176,8 +178,7 @@ python3 - << 'EOF'
 modules = [
   "smbus",
   "serial",
-  "RPi.GPIO",
-  "lgpio",
+  "gpiod",
   "sqlite3",
   "tkinter"
 ]
@@ -301,15 +302,16 @@ cd ~/Desktop/HERC-26
 rm -rf gps_venv
 python3 -m venv --system-site-packages gps_venv
 source gps_venv/bin/activate
-pip install pynmea2 pyserial RPi.GPIO smbus2
+pip install pynmea2 pyserial smbus2
 deactivate
 ```
 
-Important: do **not** try to `pip install lgpio`. `lgpio` must be installed via apt:
+Important: do **not** try to `pip install gpiod`. `python3-libgpiod` must be
+installed via apt so it links against the system libgpiod ABI:
 
 ```bash
 sudo apt update
-sudo apt install -y python3-lgpio liblgpio1
+sudo apt install -y python3-libgpiod
 ```
 
 This combination keeps the venv clean while allowing it to use system-level hardware bindings.
@@ -322,8 +324,7 @@ python3 - <<'EOF'
 modules = [
     "pynmea2",
     "serial",
-    "RPi.GPIO",
-    "lgpio",
+    "gpiod",
     "smbus",
     "sqlite3",
     "tkinter"
@@ -338,9 +339,9 @@ EOF
 ```
 
 Notes:
-- `python3-tk` (Tkinter) and `lgpio` are apt packages and must be installed via `sudo apt install`.
+- `python3-tk` (Tkinter) and `python3-libgpiod` are apt packages and must be installed via `sudo apt install`.
 - Never use `sudo pip install` for system/hardware libraries.
-- If a pip package fails to build (example: `lgpio`), install the apt package and recreate the venv with `--system-site-packages`.
+- If a pip package fails to build, install the apt equivalent and recreate the venv with `--system-site-packages`.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,13 +11,11 @@ Adafruit-PureIO==1.1.11
 binho-host-adapter==0.1.6
 colorzero==2.0
 gpiod==2.4.0
-gpiozero==2.0.1
 pyftdi==0.57.1
 pymodbus==3.11.4
 pynmea2==1.19.0
 pyserial==3.5
 pyusb==1.3.1
-RPi.GPIO==0.7.1
 rpi_ws281x==5.0.0
 setuptools==82.0.0
 smbus==1.1.post2

--- a/sensor/power_meter.py
+++ b/sensor/power_meter.py
@@ -1,6 +1,12 @@
-import os
 import time
 from serial import Serial
+
+try:
+    import gpiod
+    from gpiod.line import Direction, Value
+    _GPIOD_AVAILABLE = True
+except ImportError:
+    _GPIOD_AVAILABLE = False
 
 
 # =============================================================================
@@ -15,34 +21,85 @@ class PowerSensorReadError(Exception):
 
 
 # =============================================================================
-# GPIO SYSFS HELPERS (internal)
+# GPIO HELPERS (internal — libgpiod v2 ABI)
+#
+# Abstracted because the request_lines() call is too verbose to repeat inline.
+# _gpio_tx() / _gpio_rx() are thin semantic wrappers kept here so read() stays
+# readable as a Modbus flow, not a GPIO tutorial.
 # =============================================================================
 
-def _gpio_export(pin):
-    if not os.path.exists(f'/sys/class/gpio/gpio{pin}'):
-        with open('/sys/class/gpio/export', 'w') as f:
-            f.write(str(pin))
-        time.sleep(0.1)
+_gpio_chip    = None   # gpiod.Chip handle
+_gpio_request = None   # gpiod line request handle
+_de_re_pin    = None   # pin number (int), set in setup()
 
-def _gpio_set_direction(pin, direction):
-    with open(f'/sys/class/gpio/gpio{pin}/direction', 'w') as f:
-        f.write(direction)
 
-def _gpio_write(pin, value):
-    with open(f'/sys/class/gpio/gpio{pin}/value', 'w') as f:
-        f.write(str(value))
+def _gpio_open(chip_path: str, pin: int) -> None:
+    """
+    Open the GPIO chip and request the DE/RE line as an output, initially
+    LOW (RX mode). Stores handles in module-level _gpio_chip / _gpio_request.
 
-def _gpio_cleanup(pin):
-    if os.path.exists(f'/sys/class/gpio/gpio{pin}'):
-        with open('/sys/class/gpio/unexport', 'w') as f:
-            f.write(str(pin))
+    Raises PowerSensorSetupError if gpiod is unavailable or chip open fails.
+
+    # PLACEHOLDER: add Pi-model auto-detection here if gpio_chip needs to be
+    # resolved automatically (e.g. probe /dev/gpiochip0..4 for the right chip).
+    # For now the caller passes the chip path explicitly from config.xml.
+    """
+    global _gpio_chip, _gpio_request
+
+    if not _GPIOD_AVAILABLE:
+        raise PowerSensorSetupError(
+            "gpiod not available — install python3-libgpiod via apt"
+        )
+
+    try:
+        _gpio_chip = gpiod.Chip(chip_path)
+        _gpio_request = _gpio_chip.request_lines(
+            consumer="herc26-power-de-re",
+            config={
+                pin: gpiod.LineSettings(
+                    direction=Direction.OUTPUT,
+                    output_value=Value.INACTIVE,   # LOW = RX mode at startup
+                )
+            },
+        )
+    except Exception as e:
+        raise PowerSensorSetupError(
+            f"GPIO open failed (chip={chip_path}, pin={pin}): {e}"
+        )
+
+
+def _gpio_tx() -> None:
+    """Drive DE/RE HIGH — enables RS485 transmit mode."""
+    _gpio_request.set_value(_de_re_pin, Value.ACTIVE)
+
+
+def _gpio_rx() -> None:
+    """Drive DE/RE LOW — enables RS485 receive mode."""
+    _gpio_request.set_value(_de_re_pin, Value.INACTIVE)
+
+
+def _gpio_close() -> None:
+    """Release the GPIO line request and close the chip handle."""
+    global _gpio_chip, _gpio_request
+    if _gpio_request is not None:
+        try:
+            _gpio_request.release()
+        except Exception:
+            pass
+        _gpio_request = None
+    if _gpio_chip is not None:
+        try:
+            _gpio_chip.close()
+        except Exception:
+            pass
+        _gpio_chip = None
 
 
 # =============================================================================
 # MODBUS RTU HELPERS (internal)
 # =============================================================================
 
-def _crc16(data):
+def _crc16(data: bytes) -> int:
     crc = 0xFFFF
     for byte in data:
         crc ^= byte
@@ -58,36 +115,35 @@ def _crc16(data):
 # MODULE STATE
 # =============================================================================
 
-_ser = None
-_de_re_pin = None
+_ser            = None
 _modbus_address = 1
-_connected = False
+_connected      = False
 
 
 # =============================================================================
 # SENSOR FUNCTIONS
 # =============================================================================
 
-def setup(port="/dev/ttyAMA10", baudrate=9600, de_re_pin=17, modbus_address=1):
+def setup(port="/dev/ttyAMA10", baudrate=9600, de_re_pin=17, modbus_address=1,
+          gpio_chip="/dev/gpiochip4"):
     """
     Initialize RS485 serial and DE/RE GPIO for PZEM-017.
-    Port, baudrate, GPIO pin, and Modbus address come from config.xml at startup.
+    All parameters come from config.xml at startup — do not hardcode here.
+
+    gpio_chip: "/dev/gpiochip4" for Raspberry Pi 5 (default)
+               "/dev/gpiochip0" for Raspberry Pi 4 and earlier
     """
     global _ser, _de_re_pin, _modbus_address, _connected
-    _de_re_pin = de_re_pin
+
+    _de_re_pin      = de_re_pin
     _modbus_address = modbus_address
 
-    try:
-        _gpio_export(_de_re_pin)
-        _gpio_set_direction(_de_re_pin, 'out')
-        _gpio_write(_de_re_pin, 0)  # RX mode
-    except Exception as e:
-        raise PowerSensorSetupError(f"GPIO setup failed for pin {de_re_pin}: {e}")
+    _gpio_open(gpio_chip, de_re_pin)   # raises PowerSensorSetupError on failure
 
     try:
         _ser = Serial(port, baudrate, timeout=1)
     except Exception as e:
-        _gpio_cleanup(_de_re_pin)
+        _gpio_close()
         raise PowerSensorSetupError(f"Serial open failed on {port}: {e}")
 
     _connected = True
@@ -110,12 +166,12 @@ def read():
     try:
         _ser.reset_input_buffer()
         _ser.reset_output_buffer()
-        _gpio_write(_de_re_pin, 1)  # TX mode
+        _gpio_tx()
         time.sleep(0.01)
         _ser.write(request)
         _ser.flush()
         time.sleep(0.01)
-        _gpio_write(_de_re_pin, 0)  # RX mode
+        _gpio_rx()
         time.sleep(0.1)
         # addr(1) + FC(1) + byte_count(1) + 4 regs × 2 bytes(8) + CRC(2) = 13
         response = _ser.read(13)
@@ -148,9 +204,8 @@ def close():
     global _ser, _connected
     if _ser is not None and _ser.is_open:
         _ser.close()
-    if _de_re_pin is not None:
-        _gpio_cleanup(_de_re_pin)
-    _ser = None
+    _gpio_close()
+    _ser       = None
     _connected = False
 
 


### PR DESCRIPTION
RPi.GPIO and lgpio do not support the Pi 5 RP1 GPIO chip. Migrated all GPIO control to the libgpiod v2 character-device ABI via the Debian python3-libgpiod package (provides the `gpiod` Python module).

sensor/power_meter.py:
- Removed sysfs /sys/class/gpio helper functions (_gpio_export, _gpio_set_direction, _gpio_write, _gpio_cleanup)
- Added libgpiod v2 abstractions: _gpio_open(), _gpio_tx(), _gpio_rx(), _gpio_close() — verbose request_lines() call is isolated in _gpio_open so read() stays readable as a plain Modbus flow
- setup() gains gpio_chip parameter ("/dev/gpiochip4" Pi 5 default, "/dev/gpiochip0" for Pi 4); all params come from config.xml
- gpiod import guarded with try/except ImportError per rule 33
- _gpio_open() carries a PLACEHOLDER comment for future chip auto-detection (Pi 4 vs Pi 5 probing)

herc_26_raspberry_pi_setup_guide_readme.md:
- apt block: python3-lgpio + liblgpio1 + python3-rpi.gpio replaced with python3-libgpiod
- Dependency table updated; added Pi 5 vs Pi 4 gpiochip note
- Verify-imports blocks (step 6 + appendix): RPi.GPIO/lgpio → gpiod
- GPS venv appendix: removed RPi.GPIO from pip install line, updated lgpio apt note to python3-libgpiod

CLAUDE.md:
- Platform Constraints: smbus/lgpio/RPi.GPIO → smbus/gpiod; added explicit Pi 5 RP1 chip note with /dev/gpiochip4 vs /dev/gpiochip0
- power_meter.py module description rewritten to reflect new interface
- Known Technical Debt: power_meter.py entry updated to ✅ done
- TODO list: both CRITICAL and MEDIUM power_meter entries marked ✅

requirements.txt:
- Removed RPi.GPIO==0.7.1 (unused, incompatible with Pi 5)
- Removed gpiozero==2.0.1 (unused)
- gpiod==2.4.0 retained (now actively used)